### PR TITLE
fix: replace custom `temporary_directory`

### DIFF
--- a/src/poetry_plugin_bundle/bundlers/venv_bundler.py
+++ b/src/poetry_plugin_bundle/bundlers/venv_bundler.py
@@ -44,6 +44,7 @@ class VenvBundler(Bundler):
 
     def bundle(self, poetry: Poetry, io: IO) -> bool:
         from pathlib import Path
+        from tempfile import TemporaryDirectory
 
         from cleo.io.null_io import NullIO
         from poetry.core.masonry.builders.wheel import WheelBuilder
@@ -55,7 +56,6 @@ class VenvBundler(Bundler):
         from poetry.utils.env import EnvManager
         from poetry.utils.env import SystemEnv
         from poetry.utils.env import VirtualEnv
-        from poetry.utils.helpers import temporary_directory
 
         warnings = []
 
@@ -145,7 +145,7 @@ class VenvBundler(Bundler):
 
         # Build a wheel of the project in a temporary directory
         # and install it in the newly create virtual environment
-        with temporary_directory() as directory:
+        with TemporaryDirectory() as directory:
             try:
                 wheel_name = WheelBuilder.make_in(poetry, directory=Path(directory))
                 wheel = Path(directory).joinpath(wheel_name)

--- a/tests/bundlers/test_venv_bundler.py
+++ b/tests/bundlers/test_venv_bundler.py
@@ -52,68 +52,68 @@ def poetry(config: Config) -> Poetry:
 
 
 def test_bundler_should_build_a_new_venv_with_existing_python(
-    io: BufferedIO, tmp_dir: str, poetry: Poetry, mocker: MockerFixture
+    io: BufferedIO, tmpdir: str, poetry: Poetry, mocker: MockerFixture
 ):
-    shutil.rmtree(tmp_dir)
+    shutil.rmtree(tmpdir)
     mocker.patch("poetry.installation.executor.Executor._execute_operation")
 
     bundler = VenvBundler()
-    bundler.set_path(Path(tmp_dir))
+    bundler.set_path(Path(tmpdir))
 
     assert bundler.bundle(poetry, io)
 
     python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
-  • Bundling simple-project (1.2.3) into {tmp_dir}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Creating a virtual environment using Python {python_version}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Installing dependencies
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Installing simple-project (1.2.3)
-  • Bundled simple-project (1.2.3) into {tmp_dir}
+  • Bundling simple-project (1.2.3) into {tmpdir}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
+  • Bundling simple-project (1.2.3) into {tmpdir}: Installing simple-project (1.2.3)
+  • Bundled simple-project (1.2.3) into {tmpdir}
 """  # noqa: E501
     assert expected == io.fetch_output()
 
 
 def test_bundler_should_build_a_new_venv_with_given_executable(
-    io: BufferedIO, tmp_dir: str, poetry: Poetry, mocker: MockerFixture
+    io: BufferedIO, tmpdir: str, poetry: Poetry, mocker: MockerFixture
 ):
-    shutil.rmtree(tmp_dir)
+    shutil.rmtree(tmpdir)
     mocker.patch("poetry.installation.executor.Executor._execute_operation")
 
     bundler = VenvBundler()
-    bundler.set_path(Path(tmp_dir))
+    bundler.set_path(Path(tmpdir))
     bundler.set_executable(sys.executable)
 
     assert bundler.bundle(poetry, io)
 
     python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
-  • Bundling simple-project (1.2.3) into {tmp_dir}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Creating a virtual environment using Python {python_version}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Installing dependencies
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Installing simple-project (1.2.3)
-  • Bundled simple-project (1.2.3) into {tmp_dir}
+  • Bundling simple-project (1.2.3) into {tmpdir}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
+  • Bundling simple-project (1.2.3) into {tmpdir}: Installing simple-project (1.2.3)
+  • Bundled simple-project (1.2.3) into {tmpdir}
 """  # noqa: E501
     assert expected == io.fetch_output()
 
 
 def test_bundler_should_build_a_new_venv_if_existing_venv_is_incompatible(
-    io: BufferedIO, tmp_dir: str, poetry: Poetry, mocker: MockerFixture
+    io: BufferedIO, tmpdir: str, poetry: Poetry, mocker: MockerFixture
 ):
     mocker.patch("poetry.installation.executor.Executor._execute_operation")
 
     bundler = VenvBundler()
-    bundler.set_path(Path(tmp_dir))
+    bundler.set_path(Path(tmpdir))
 
     assert bundler.bundle(poetry, io)
 
     python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
-  • Bundling simple-project (1.2.3) into {tmp_dir}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Creating a virtual environment using Python {python_version}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Installing dependencies
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Installing simple-project (1.2.3)
-  • Bundled simple-project (1.2.3) into {tmp_dir}
+  • Bundling simple-project (1.2.3) into {tmpdir}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Removing existing virtual environment
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
+  • Bundling simple-project (1.2.3) into {tmpdir}: Installing simple-project (1.2.3)
+  • Bundled simple-project (1.2.3) into {tmpdir}
 """  # noqa: E501
     assert expected == io.fetch_output()
 
@@ -164,7 +164,7 @@ def test_bundler_should_remove_an_existing_venv_if_forced(
 
 
 def test_bundler_should_fail_when_installation_fails(
-    io: BufferedIO, tmp_dir: str, poetry: Poetry, mocker: MockerFixture
+    io: BufferedIO, tmpdir: str, poetry: Poetry, mocker: MockerFixture
 ):
     mocker.patch(
         "poetry.installation.executor.Executor._do_execute_operation",
@@ -172,17 +172,17 @@ def test_bundler_should_fail_when_installation_fails(
     )
 
     bundler = VenvBundler()
-    bundler.set_path(Path(tmp_dir))
+    bundler.set_path(Path(tmpdir))
 
     assert not bundler.bundle(poetry, io)
 
     python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
-  • Bundling simple-project (1.2.3) into {tmp_dir}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Creating a virtual environment using Python {python_version}
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Installing dependencies
-  • Bundling simple-project (1.2.3) into {tmp_dir}: Failed at step Installing dependencies
+  • Bundling simple-project (1.2.3) into {tmpdir}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Removing existing virtual environment
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
+  • Bundling simple-project (1.2.3) into {tmpdir}: Failed at step Installing dependencies
 """  # noqa: E501
     assert expected == io.fetch_output()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import shutil
-import tempfile
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Iterator
 
@@ -16,12 +14,14 @@ from poetry.utils.env import VirtualEnv
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from pytest_mock import MockerFixture
 
 
 @pytest.fixture
-def config_cache_dir(tmp_dir: str) -> Path:
-    path = Path(tmp_dir) / ".cache" / "pypoetry"
+def config_cache_dir(tmp_path: Path) -> Path:
+    path = tmp_path / ".cache" / "pypoetry"
     path.mkdir(parents=True)
     return path
 
@@ -70,17 +70,8 @@ def config(
 
 
 @pytest.fixture
-def tmp_dir() -> Iterator[str]:
-    dir_ = tempfile.mkdtemp(prefix="poetry_plugin_bundle_")
-
-    yield dir_
-
-    shutil.rmtree(dir_)
-
-
-@pytest.fixture
-def tmp_venv(tmp_dir: str) -> Iterator[VirtualEnv]:
-    venv_path = Path(tmp_dir) / "venv"
+def tmp_venv(tmp_path: Path) -> Iterator[VirtualEnv]:
+    venv_path = tmp_path / "venv"
 
     EnvManager.build_venv(str(venv_path))
 


### PR DESCRIPTION
Follow up after #11 to handle `temporary_directory` removed from latest poetry
