### PR TITLE
release: bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Change Log
+
+
+## [1.1.0] - 2022-11-04
+
+### Added
+
+- Add support for dependency groups ([#26](https://github.com/python-poetry/poetry-plugin-bundle/pull/26)).
+
+
+## [1.0.0] - 2022-08-24
+
+Initial version.
+
+
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-bundle/compare/1.1.0...main
+[1.1.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.1.0
+[1.0.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-bundle"
-version = "1.0.0"
+version = "1.1.0"
 description = "Poetry plugin to bundle projects into various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Add support for dependency groups ([#26](https://github.com/python-poetry/poetry-plugin-bundle/pull/26)).