### PR TITLE
Migrate from flake8 to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,25 +25,6 @@ repos:
       - id: python-use-type-annotations
       - id: python-check-blanket-noqa
 
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-      - id: yesqa
-        additional_dependencies: &flake8_deps
-          - flake8-annotations==3.0.0
-          - flake8-broken-line==0.6.0
-          - flake8-bugbear==23.2.13
-          - flake8-comprehensions==3.10.1
-          - flake8-eradicate==1.4.0
-          - flake8-no-pep420==2.3.0
-          - flake8-quotes==3.3.2
-          - flake8-simplify==0.19.3
-          - flake8-tidy-imports==4.8.0
-          - flake8-type-checking==2.3.0
-          - flake8-typing-imports==1.14.0
-          - flake8-use-fstring==1.4
-          - pep8-naming==0.13.3
-
   - repo: https://github.com/asottile/pyupgrade
     rev: v3.3.1
     hooks:
@@ -67,8 +48,7 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.262
     hooks:
-      - id: flake8
-        additional_dependencies: *flake8_deps
+    -   id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
         args: [--lines-after-imports, "-1"]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
       - id: black
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,39 @@ pytest-github-actions-annotate-failures = "^0.1.7"
 [tool.poetry.plugins."poetry.application.plugin"]
 export = "poetry_plugin_bundle.plugin:BundleApplicationPlugin"
 
+
+[tool.ruff]
+fix = true
+unfixable = [
+    "ERA",  # do not autoremove commented out code
+]
+target-version = "py37"
+line-length = 88
+extend-select = [
+    "B",  # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "ERA",  # flake8-eradicate/eradicate
+    "PIE",  # flake8-pie
+    "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
+    "TCH",  # flake8-type-checking
+    "N",  # pep8-naming
+    "RUF",  # ruff checks
+]
+ignore = [
+    "B904",  # use 'raise ... from err'
+    "B905",  # use explicit 'strict=' parameter with 'zip()'
+    "N818"  #  Exception name should be named with an Error suffix
+]
+extend-exclude = [
+    # External to the project's coding standards
+    "tests/**/fixtures/*",
+]
+
+[tool.ruff.flake8-tidy-imports]
+ban-relative-imports = "all"
+
+
 [tool.black]
 target-version = ['py37']
 preview = true

--- a/src/poetry_plugin_bundle/console/commands/bundle/bundle_command.py
+++ b/src/poetry_plugin_bundle/console/commands/bundle/bundle_command.py
@@ -33,7 +33,6 @@ class BundleCommand(GroupCommand):
         """
         Configure the given bundler based on command specific options and arguments.
         """
-        pass
 
     def handle(self) -> int:
         self.line("")


### PR DESCRIPTION
Closes: #49 

Pre-commit hooks update and migration to `ruff`.