### PR TITLE
Fix compatibility with Poetry 1.5+

### DIFF
--- a/src/poetry_plugin_bundle/bundlers/venv_bundler.py
+++ b/src/poetry_plugin_bundle/bundlers/venv_bundler.py
@@ -134,8 +134,8 @@ class VenvBundler(Bundler):
         if self._activated_groups is not None:
             installer.only_groups(self._activated_groups)
         installer.requires_synchronization()
-        use_executor = poetry.config.get("experimental.new-installer", False)
-        if not use_executor:
+        use_executor = poetry.config.get("experimental.new-installer", None)
+        if use_executor is not None and not use_executor:
             # only set if false because the method is deprecated
             installer.use_executor(False)
 


### PR DESCRIPTION
Poetry 1.5 removed the configuration parameter `experimental.new-installer` completely, resulting in `poetry.config.get("experimental.new-installer", False)` returning its default value `False`. That made this plugin try to use the `use_executor` method on the Installer object, which doesn't exist.

This change makes the plugin use the `use_executor` method only if the config param really exists and has a non-True value, which allows it to work with Poetry 1.5 while maintaining backwards compatibility.