### PR TITLE
feat: compile flag for installer

### DIFF
--- a/src/poetry_plugin_bundle/bundlers/venv_bundler.py
+++ b/src/poetry_plugin_bundle/bundlers/venv_bundler.py
@@ -25,6 +25,7 @@ class VenvBundler(Bundler):
         self._executable: str | None = None
         self._remove: bool = False
         self._activated_groups: set[str] | None = None
+        self._compile: bool = False
 
     def set_path(self, path: Path) -> VenvBundler:
         self._path = path
@@ -43,6 +44,11 @@ class VenvBundler(Bundler):
 
     def set_remove(self, remove: bool = True) -> VenvBundler:
         self._remove = remove
+
+        return self
+
+    def set_compile(self, compile: bool = False) -> VenvBundler:
+        self._compile = compile
 
         return self
 
@@ -129,6 +135,8 @@ class VenvBundler(Bundler):
         if self._activated_groups is not None:
             installer.only_groups(self._activated_groups)
         installer.requires_synchronization()
+
+        installer.executor.enable_bytecode_compilation(self._compile)
 
         return_code = installer.run()
         if return_code:

--- a/src/poetry_plugin_bundle/console/commands/bundle/venv.py
+++ b/src/poetry_plugin_bundle/console/commands/bundle/venv.py
@@ -37,6 +37,14 @@ class BundleVenvCommand(BundleCommand):
             "Clear the existing virtual environment if it exists. ",
             flag=True,
         ),
+        option(
+            "compile",
+            None,
+            "Compile Python source files to bytecode."
+            " (This option has no effect if modern-installation is disabled"
+            " because the old installer always compiles.)",
+            flag=True,
+        ),
     ]
 
     bundler_name = "venv"
@@ -45,4 +53,5 @@ class BundleVenvCommand(BundleCommand):
         bundler.set_path(Path(self.argument("path")))
         bundler.set_executable(self.option("python"))
         bundler.set_remove(self.option("clear"))
+        bundler.set_compile(self.option("compile"))
         bundler.set_activated_groups(self.activated_groups)


### PR DESCRIPTION
Hi! First PR here 😅 

I noticed that `--compile` option used in `poetry install` is not utilized in venv bundler.

In this PR I added a passthrough of the flag to the installer as in poetry itself:

https://github.com/python-poetry/poetry/blob/d18ca5d2e751d5a44e48da38926662c90bcb23d1/src/poetry/console/commands/install.py#L147