### PR TITLE
Allow Poetry to select best Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ will bundle the project in the `/path/to/environment` directory by creating the 
 installing the dependencies and the current project inside it. If the directory does not exist,
 it will be created automatically.
 
-By default, the command uses the current Python executable to build the virtual environment.
+By default, the command uses the same Python executable that Poetry would use
+when running `poetry install` to build the virtual environment.
 If you want to use a different one, you can specify it with the `--python/-p` option:
 
 ```bash

--- a/src/poetry_plugin_bundle/bundlers/venv_bundler.py
+++ b/src/poetry_plugin_bundle/bundlers/venv_bundler.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import subprocess
-import sys
-
 from pathlib import Path
-from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from poetry_plugin_bundle.bundlers.bundler import Bundler
@@ -13,7 +9,6 @@ from poetry_plugin_bundle.bundlers.bundler import Bundler
 if TYPE_CHECKING:
     from cleo.io.io import IO
     from cleo.io.outputs.section_output import SectionOutput
-    from poetry.core.constraints.version import Version
     from poetry.poetry import Poetry
     from poetry.repositories.lockfile_repository import LockfileRepository
 
@@ -58,7 +53,6 @@ class VenvBundler(Bundler):
         from tempfile import TemporaryDirectory
 
         from cleo.io.null_io import NullIO
-        from poetry.core.constraints.version import Version
         from poetry.core.masonry.builders.wheel import WheelBuilder
         from poetry.core.masonry.utils.module import ModuleOrPackageNotFound
         from poetry.core.packages.package import Package
@@ -66,18 +60,30 @@ class VenvBundler(Bundler):
         from poetry.installation.operations.install import Install
         from poetry.packages.locker import Locker
         from poetry.utils.env import EnvManager
-        from poetry.utils.env import SystemEnv
         from poetry.utils.env import VirtualEnv
+
+        class CustomEnvManager(EnvManager):
+            """
+            This class is used as an adapter for allowing us to use Poetry's EnvManager.create_venv but with
+            a custom path.
+            It works by hijacking the "in_project_venv" concept so that we can get that behavior, but with a custom
+            path.
+            """
+            @property
+            def in_project_venv(self) -> Path:
+                return self._path
+
+            def use_in_project_venv(self) -> bool:
+                return True
+
+            def create_venv_at_path(self, path: Path, executable: Path | None = None):
+                self._path = path
+                self.create_venv(name=None, executable=executable, force=True)
 
         warnings = []
 
-        manager = EnvManager(poetry)
-        if self._executable:
-            executable, python_version = self._get_executable_info(self._executable)
-        else:
-            executable = None
-            version_info = SystemEnv(Path(sys.prefix)).get_version_info()
-            python_version = Version.parse(".".join(str(v) for v in version_info[:3]))
+        manager = CustomEnvManager(poetry)
+        executable = Path(self._executable) if self._executable else None
 
         message = self._get_message(poetry, self._path)
         if io.is_decorated() and not io.is_debug():
@@ -85,42 +91,19 @@ class VenvBundler(Bundler):
 
         io.write_line(message)
 
-        if self._path.exists():
-            env = VirtualEnv(self._path)
-            env_python_version = Version.parse(
-                ".".join(str(v) for v in env.version_info[:3])
-            )
-
-            if (
-                not env.is_sane()
-                or env_python_version != python_version
-                or self._remove
-            ):
-                self._write(
-                    io, f"{message}: <info>Removing existing virtual environment</info>"
-                )
-
-                manager.remove_venv(self._path)
-
-                self._write(
-                    io,
-                    f"{message}: <info>Creating a virtual environment using Python"
-                    f" <b>{python_version}</b></info>",
-                )
-
-                manager.build_venv(self._path, executable=executable)
-            else:
-                self._write(
-                    io, f"{message}: <info>Using existing virtual environment</info>"
-                )
-        else:
+        if executable:
             self._write(
                 io,
                 f"{message}: <info>Creating a virtual environment using Python"
-                f" <b>{python_version}</b></info>",
+                f" <b>{executable}</b></info>",
+            )
+        else:
+            self._write(
+                io,
+                f"{message}: <info>Creating a virtual environment using Poetry-determined Python"
             )
 
-            manager.build_venv(self._path, executable=executable)
+        manager.create_venv_at_path(self._path, executable=executable)
 
         env = VirtualEnv(self._path)
 
@@ -221,32 +204,3 @@ class VenvBundler(Bundler):
             return
 
         io.overwrite(message)
-
-    def _get_executable_info(self, executable: str) -> tuple[Path, Version]:
-        from poetry.core.constraints.version import Version
-
-        try:
-            python_version = Version.parse(executable)
-            executable = f"python{python_version.major}"
-            if python_version.precision > 1:
-                executable += f".{python_version.minor}"
-        except ValueError:
-            # Executable in PATH or full executable path
-            pass
-
-        try:
-            python_version_str = subprocess.check_output(
-                [
-                    executable,
-                    "-c",
-                    "import sys; print('.'.join([str(s) for s in sys.version_info[:3]]))",
-                ]
-            ).decode()
-        except CalledProcessError as e:
-            from poetry.utils.env import EnvCommandError
-
-            raise EnvCommandError(e) from None
-
-        python_version = Version.parse(python_version_str.strip())
-
-        return Path(executable), python_version

--- a/src/poetry_plugin_bundle/bundlers/venv_bundler.py
+++ b/src/poetry_plugin_bundle/bundlers/venv_bundler.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from poetry_plugin_bundle.bundlers.bundler import Bundler
 
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from cleo.io.io import IO
     from cleo.io.outputs.section_output import SectionOutput
     from poetry.poetry import Poetry
@@ -59,8 +60,8 @@ class VenvBundler(Bundler):
         from poetry.installation.installer import Installer
         from poetry.installation.operations.install import Install
         from poetry.packages.locker import Locker
-        from poetry.utils.env import EnvManager
         from poetry.utils.env import Env
+        from poetry.utils.env import EnvManager
         from poetry.utils.env.exceptions import InvalidCurrentPythonVersionError
 
         class CustomEnvManager(EnvManager):
@@ -70,6 +71,7 @@ class VenvBundler(Bundler):
             It works by hijacking the "in_project_venv" concept so that we can get that behavior, but with a custom
             path.
             """
+
             @property
             def in_project_venv(self) -> Path:
                 return self._path
@@ -77,7 +79,9 @@ class VenvBundler(Bundler):
             def use_in_project_venv(self) -> bool:
                 return True
 
-            def create_venv_at_path(self, path: Path, executable: Path | None, force: bool) -> Env:
+            def create_venv_at_path(
+                self, path: Path, executable: Path | None, force: bool
+            ) -> Env:
                 self._path = path
                 return self.create_venv(name=None, executable=executable, force=force)
 
@@ -101,16 +105,21 @@ class VenvBundler(Bundler):
         else:
             self._write(
                 io,
-                f"{message}: <info>Creating a virtual environment using Poetry-determined Python"
+                f"{message}: <info>Creating a virtual environment using Poetry-determined Python",
             )
 
         try:
-            env = manager.create_venv_at_path(self._path, executable=executable, force=self._remove)
+            env = manager.create_venv_at_path(
+                self._path, executable=executable, force=self._remove
+            )
         except InvalidCurrentPythonVersionError:
             self._write(
-                io, f"{message}: <info>Replacing existing virtual environment due to incompatible Python version</info>"
+                io,
+                f"{message}: <info>Replacing existing virtual environment due to incompatible Python version</info>",
             )
-            env = manager.create_venv_at_path(self._path, executable=executable, force=True)
+            env = manager.create_venv_at_path(
+                self._path, executable=executable, force=True
+            )
 
         self._write(io, f"{message}: <info>Installing dependencies</info>")
 

--- a/src/poetry_plugin_bundle/bundlers/venv_bundler.py
+++ b/src/poetry_plugin_bundle/bundlers/venv_bundler.py
@@ -66,10 +66,10 @@ class VenvBundler(Bundler):
 
         class CustomEnvManager(EnvManager):
             """
-            This class is used as an adapter for allowing us to use Poetry's EnvManager.create_venv but with
-            a custom path.
-            It works by hijacking the "in_project_venv" concept so that we can get that behavior, but with a custom
-            path.
+            This class is used as an adapter for allowing us to use
+            Poetry's EnvManager.create_venv but with a custom path.
+            It works by hijacking the "in_project_venv" concept so that
+            we can get that behavior, but with a custom path.
             """
 
             @property
@@ -105,7 +105,8 @@ class VenvBundler(Bundler):
         else:
             self._write(
                 io,
-                f"{message}: <info>Creating a virtual environment using Poetry-determined Python",
+                f"{message}: <info>Creating a virtual environment"
+                " using Poetry-determined Python",
             )
 
         try:
@@ -115,7 +116,8 @@ class VenvBundler(Bundler):
         except InvalidCurrentPythonVersionError:
             self._write(
                 io,
-                f"{message}: <info>Replacing existing virtual environment due to incompatible Python version</info>",
+                f"{message}: <info>Replacing existing virtual environment"
+                " due to incompatible Python version</info>",
             )
             env = manager.create_venv_at_path(
                 self._path, executable=executable, force=True

--- a/src/poetry_plugin_bundle/bundlers/venv_bundler.py
+++ b/src/poetry_plugin_bundle/bundlers/venv_bundler.py
@@ -76,9 +76,9 @@ class VenvBundler(Bundler):
             def use_in_project_venv(self) -> bool:
                 return True
 
-            def create_venv_at_path(self, path: Path, executable: Path | None = None):
+            def create_venv_at_path(self, path: Path, executable: Path | None, force: bool):
                 self._path = path
-                self.create_venv(name=None, executable=executable, force=True)
+                self.create_venv(name=None, executable=executable, force=force)
 
         warnings = []
 
@@ -103,7 +103,7 @@ class VenvBundler(Bundler):
                 f"{message}: <info>Creating a virtual environment using Poetry-determined Python"
             )
 
-        manager.create_venv_at_path(self._path, executable=executable)
+        manager.create_venv_at_path(self._path, executable=executable, force=self._remove)
 
         env = VirtualEnv(self._path)
 

--- a/tests/bundlers/test_venv_bundler.py
+++ b/tests/bundlers/test_venv_bundler.py
@@ -15,8 +15,8 @@ from poetry.factory import Factory
 from poetry.installation.operations.install import Install
 from poetry.puzzle.exceptions import SolverProblemError
 from poetry.repositories.repository import Repository
-from poetry.utils.env import MockEnv
 from poetry.repositories.repository_pool import RepositoryPool
+from poetry.utils.env import MockEnv
 
 from poetry_plugin_bundle.bundlers.venv_bundler import VenvBundler
 
@@ -54,7 +54,7 @@ def poetry(config: Config) -> Poetry:
     return poetry
 
 
-def _create_venv_marker_file(tempdir: str) -> Path:
+def _create_venv_marker_file(tempdir: str | Path) -> Path:
     marker_file = Path(tempdir) / "existing-venv-marker.txt"
     marker_file.write_text("This file should get deleted as part of venv recreation.")
     return marker_file

--- a/tests/bundlers/test_venv_bundler.py
+++ b/tests/bundlers/test_venv_bundler.py
@@ -15,6 +15,7 @@ from poetry.factory import Factory
 from poetry.installation.operations.install import Install
 from poetry.puzzle.exceptions import SolverProblemError
 from poetry.repositories.repository import Repository
+from poetry.utils.env import MockEnv
 from poetry.repositories.repository_pool import RepositoryPool
 
 from poetry_plugin_bundle.bundlers.venv_bundler import VenvBundler
@@ -107,6 +108,9 @@ def test_bundler_should_build_a_new_venv_if_existing_venv_is_incompatible(
 ) -> None:
     mocker.patch("poetry.installation.executor.Executor._execute_operation")
 
+    mock_env = MockEnv(path=Path(tmpdir), is_venv=True, version_info=(1, 2, 3))
+    mocker.patch("poetry.utils.env.EnvManager.get", return_value=mock_env)
+
     bundler = VenvBundler()
     bundler.set_path(Path(tmpdir))
 
@@ -119,6 +123,7 @@ def test_bundler_should_build_a_new_venv_if_existing_venv_is_incompatible(
     expected = f"""\
   • Bundling simple-project (1.2.3) into {tmpdir}
   • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Poetry-determined Python
+  • Bundling simple-project (1.2.3) into {tmpdir}: Replacing existing virtual environment due to incompatible Python version
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {tmpdir}

--- a/tests/bundlers/test_venv_bundler.py
+++ b/tests/bundlers/test_venv_bundler.py
@@ -307,11 +307,9 @@ def test_bundler_passes_compile_flag(
     mocker.assert_called_once_with(compile)
 
     path = str(tmp_venv.path)
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {path}
-  • Bundling simple-project (1.2.3) into {path}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {path}: Installing dependencies
   • Bundling simple-project (1.2.3) into {path}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {path}
@@ -338,11 +336,9 @@ def test_bundler_editable_deps(
     bundler.bundle(poetry, io)
 
     path = tmpdir
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {path}
-  • Bundling simple-project (1.2.3) into {path}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {path}: Installing dependencies
   • Bundling simple-project (1.2.3) into {path}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {path}

--- a/tests/bundlers/test_venv_bundler.py
+++ b/tests/bundlers/test_venv_bundler.py
@@ -53,6 +53,12 @@ def poetry(config: Config) -> Poetry:
     return poetry
 
 
+def _create_venv_marker_file(tempdir: str) -> Path:
+    marker_file = Path(tempdir) / "existing-venv-marker.txt"
+    marker_file.write_text("This file should get deleted as part of venv recreation.")
+    return marker_file
+
+
 def test_bundler_should_build_a_new_venv_with_existing_python(
     io: BufferedIO, tmpdir: str, poetry: Poetry, mocker: MockerFixture
 ) -> None:
@@ -64,10 +70,9 @@ def test_bundler_should_build_a_new_venv_with_existing_python(
 
     assert bundler.bundle(poetry, io)
 
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {tmpdir}
-  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {tmpdir}
@@ -87,10 +92,9 @@ def test_bundler_should_build_a_new_venv_with_given_executable(
 
     assert bundler.bundle(poetry, io)
 
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {tmpdir}
-  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {sys.executable}
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {tmpdir}
@@ -106,13 +110,15 @@ def test_bundler_should_build_a_new_venv_if_existing_venv_is_incompatible(
     bundler = VenvBundler()
     bundler.set_path(Path(tmpdir))
 
-    assert bundler.bundle(poetry, io)
+    marker_file = _create_venv_marker_file(tmpdir)
 
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
+    assert marker_file.exists()
+    assert bundler.bundle(poetry, io)
+    assert not marker_file.exists()
+
     expected = f"""\
   • Bundling simple-project (1.2.3) into {tmpdir}
-  • Bundling simple-project (1.2.3) into {tmpdir}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {tmpdir}
@@ -128,12 +134,16 @@ def test_bundler_should_use_an_existing_venv_if_compatible(
     bundler = VenvBundler()
     bundler.set_path(tmp_venv.path)
 
+    marker_file = _create_venv_marker_file(tmp_venv.path)
+
+    assert marker_file.exists()
     assert bundler.bundle(poetry, io)
+    assert marker_file.exists()
 
     path = str(tmp_venv.path)
     expected = f"""\
   • Bundling simple-project (1.2.3) into {path}
-  • Bundling simple-project (1.2.3) into {path}: Using existing virtual environment
+  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {path}: Installing dependencies
   • Bundling simple-project (1.2.3) into {path}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {path}
@@ -150,14 +160,16 @@ def test_bundler_should_remove_an_existing_venv_if_forced(
     bundler.set_path(tmp_venv.path)
     bundler.set_remove(True)
 
+    marker_file = _create_venv_marker_file(tmp_venv.path)
+
+    assert marker_file.exists()
     assert bundler.bundle(poetry, io)
+    assert not marker_file.exists()
 
     path = str(tmp_venv.path)
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {path}
-  • Bundling simple-project (1.2.3) into {path}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {path}: Installing dependencies
   • Bundling simple-project (1.2.3) into {path}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {path}
@@ -178,11 +190,9 @@ def test_bundler_should_fail_when_installation_fails(
 
     assert not bundler.bundle(poetry, io)
 
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {tmpdir}
-  • Bundling simple-project (1.2.3) into {tmpdir}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {tmpdir}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {tmpdir}: Installing dependencies
   • Bundling simple-project (1.2.3) into {tmpdir}: Failed at step Installing dependencies
 """
@@ -212,11 +222,9 @@ def test_bundler_should_display_a_warning_for_projects_with_no_module(
     assert bundler.bundle(poetry, io)
 
     path = str(tmp_venv.path)
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {path}
-  • Bundling simple-project (1.2.3) into {path}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {path}: Installing dependencies
   • Bundling simple-project (1.2.3) into {path}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {path}
@@ -259,11 +267,9 @@ def test_bundler_can_filter_dependency_groups(
     assert bundler.bundle(poetry, io)
 
     path = tmpdir
-    python_version = ".".join(str(v) for v in sys.version_info[:3])
     expected = f"""\
   • Bundling simple-project (1.2.3) into {path}
-  • Bundling simple-project (1.2.3) into {path}: Removing existing virtual environment
-  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Python {python_version}
+  • Bundling simple-project (1.2.3) into {path}: Creating a virtual environment using Poetry-determined Python
   • Bundling simple-project (1.2.3) into {path}: Installing dependencies
   • Bundling simple-project (1.2.3) into {path}: Installing simple-project (1.2.3)
   • Bundled simple-project (1.2.3) into {path}


### PR DESCRIPTION
Resolves: #76

This PR alters the `VenvBundle` virtual environment creation to leverage Poetry's ability to select the "best" Python version to use based upon the pyproject's `python` dependency specification.

- A subclass of `EnvManager` is used to override the "in_project_venv" methods as a way to leverage the Poetry behavior we need to (re)create a venv at an arbitrary location.
- All checking of existing venv is now done in Poetry, and so code related to that is removed from VenvBundle
- `InvalidCurrentPythonVersionError` exception handling is used to deal with existing venv that is incompatible. Poetry raises an exception in this case, so the solution I implemented to support this use case is to call `create_venv` again with `force=True`