### PR TITLE
release: bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Change Log
 
 
+## [1.4.0] - 2024-07-26
+
+### Added
+
+- Add a `--compile` option analogous to `poetry install` ([#88](https://github.com/python-poetry/poetry-plugin-bundle/pull/88)).
+
+### Changed
+
+- Drop support for Python 3.7 ([#66](https://github.com/python-poetry/poetry-plugin-bundle/pull/66)).
+- Install all dependencies as non-editable ([#106](https://github.com/python-poetry/poetry-plugin-bundle/pull/106)).
+- Use same logic as `poetry install` to determine the Python version if not provided explicitly ([#103](https://github.com/python-poetry/poetry-plugin-bundle/pull/103)).
+
+
 ## [1.3.0] - 2023-05-29
 
 ### Added
@@ -31,7 +44,8 @@
 Initial version.
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-bundle/compare/1.3.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-bundle/compare/1.4.0...main
+[1.4.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.4.0
 [1.3.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.3.0
 [1.2.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.2.0
 [1.1.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-plugin-bundle"
-version = "1.3.0"
+version = "1.4.0"
 description = "Poetry plugin to bundle projects into various formats"
 authors = ["Sébastien Eustace <sebastien@eustace.io>"]
 license = "MIT"


### PR DESCRIPTION
### Added

- Add a `--compile` option analogous to `poetry install` ([#88](https://github.com/python-poetry/poetry-plugin-bundle/pull/88)).

### Changed

- Drop support for Python 3.7 ([#66](https://github.com/python-poetry/poetry-plugin-bundle/pull/66)).
- Install all dependencies as non-editable ([#106](https://github.com/python-poetry/poetry-plugin-bundle/pull/106)).
- Use same logic as `poetry install` to determine the Python version if not provided explicitly ([#103](https://github.com/python-poetry/poetry-plugin-bundle/pull/103)).