### PR TITLE
release: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,22 @@
 # Change Log
 
 
+## [1.6.0] - 2024-02-16
+
+### Added
+
+- Ensure compatibility with Poetry 2.1 ([#137](https://github.com/python-poetry/poetry-plugin-bundle/pull/137)).
+
+### Changed
+
+- Drop support for older Poetry versions ([#137](https://github.com/python-poetry/poetry-plugin-bundle/pull/137)).
+
+
 ## [1.5.0] - 2024-01-05
 
 ### Added
 
-- Ensure compatiblity with Poetry 2.0 ([#128](https://github.com/python-poetry/poetry-plugin-bundle/pull/128)).
+- Ensure compatibility with Poetry 2.0 ([#128](https://github.com/python-poetry/poetry-plugin-bundle/pull/128)).
 - Add support for projects with `package-mode = false` ([#119](https://github.com/python-poetry/poetry-plugin-bundle/pull/119)).
 
 ### Changed
@@ -63,7 +74,8 @@
 Initial version.
 
 
-[Unreleased]: https://github.com/python-poetry/poetry-plugin-bundle/compare/1.5.0...main
+[Unreleased]: https://github.com/python-poetry/poetry-plugin-bundle/compare/1.6.0...main
+[1.6.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.6.0
 [1.5.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.5.0
 [1.4.1]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.4.1
 [1.4.0]: https://github.com/python-poetry/poetry-plugin-bundle/releases/tag/1.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "poetry-plugin-bundle"
-version = "1.5.0"
+version = "1.6.0"
 description = "Poetry plugin to bundle projects into various formats"
 authors = [{ name = "Sébastien Eustace", email = "sebastien@eustace.io" }]
 license = { text = "MIT" }


### PR DESCRIPTION
### Added

- Ensure compatibility with Poetry 2.1 ([#137](https://github.com/python-poetry/poetry-plugin-bundle/pull/137)).

### Changed

- Drop support for older Poetry versions ([#137](https://github.com/python-poetry/poetry-plugin-bundle/pull/137)).